### PR TITLE
Add Docker setup for backend

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:18
+WORKDIR /app
+
+COPY package.json ./
+COPY pnpm-lock.yaml ./
+RUN npm install
+
+COPY . .
+RUN npx prisma generate
+
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+EXPOSE 3001
+CMD ["docker-entrypoint.sh"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -20,6 +20,16 @@
     npm start
     ```
 
+## Rodando com Docker
+
+1. Garanta que você tenha o [Docker](https://www.docker.com/) e o
+   [Docker&nbsp;Compose](https://docs.docker.com/compose/) instalados.
+2. Na raiz do projeto execute:
+   ```bash
+   docker-compose up --build
+   ```
+   Isso irá subir um contêiner PostgreSQL e o backend na porta `3001`.
+
 ## Notificações automáticas
 
 As notificações de agendamento, cancelamento e confirmação de consultas são simuladas via console (mock). Para produção, integre um serviço real de e-mail/SMS em `src/utils/email.js`.

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Run database migrations and seed data, then start the server
+npx prisma migrate deploy
+node scripts/seed.js
+npm start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.8'
+
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: medical
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+  backend:
+    build: ./backend
+    environment:
+      DATABASE_URL: postgres://postgres:postgres@db:5432/medical
+      JWT_SECRET: supersecret
+    depends_on:
+      - db
+    ports:
+      - "3001:3001"
+
+volumes:
+  db-data:


### PR DESCRIPTION
## Summary
- add Dockerfile and entrypoint script for backend
- provide docker-compose with Postgres service
- document how to run backend with Docker

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' because the environment lacks dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686c91f75a2c832a9591a18d61758793