### PR TITLE
Add Cypress and Jest tests

### DIFF
--- a/frontend/TEST_PLAN.md
+++ b/frontend/TEST_PLAN.md
@@ -1,0 +1,20 @@
+# Plano de Testes
+
+Este projeto possui três entidades principais: Paciente, Médico e Consulta. Os testes automatizados cobrem os fluxos principais, alternativos e de exceção de cada caso de uso.
+
+## Casos de Uso Testados
+
+1. **Listagem de Médicos**
+   - **Fluxo principal:** exibe a lista de médicos disponíveis.
+   - **Fluxo alternativo:** aplica filtro por especialidade.
+   - **Fluxo de exceção:** trata falha na API exibindo mensagem de erro.
+2. **Gerenciamento de Pacientes**
+   - **Fluxo principal:** médico visualiza lista de pacientes vinculados.
+   - **Fluxo alternativo:** médico busca paciente pelo nome.
+   - **Fluxo de exceção:** usuário paciente é redirecionado ao tentar acessar a tela.
+3. **Gerenciamento de Consultas**
+   - **Fluxo principal:** usuário visualiza suas consultas agendadas.
+   - **Fluxo alternativo:** cancela uma consulta existente.
+   - **Fluxo de exceção:** exibe estado vazio quando não há consultas.
+
+Cada caso de uso possui três testes automatizados, totalizando nove cenários de sistema. Além disso, há testes unitários para utilitários de formatação e testes de integração para os serviços de API.

--- a/frontend/cypress/e2e/app/appointments.cy.js
+++ b/frontend/cypress/e2e/app/appointments.cy.js
@@ -1,0 +1,33 @@
+/// <reference types="cypress" />
+
+describe('Appointments use case', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '/appointments', {
+      appointments: [
+        { id: '1', status: 'SCHEDULED', date: '2024-01-01T10:00', doctor: { name: 'Ana', specialty: 'Cardio' } }
+      ]
+    });
+  });
+
+  it('principal flow - list appointments', () => {
+    cy.setCookie('token', 'patient');
+    cy.visit('/appointments');
+    cy.get('[data-testid="appointment-card"]').should('have.length', 1);
+  });
+
+  it('alternative flow - cancel appointment', () => {
+    cy.setCookie('token', 'patient');
+    cy.intercept('DELETE', '/appointments/1', {});
+    cy.visit('/appointments');
+    cy.get('[data-testid="cancel-appointment"]').click();
+    cy.get('[data-testid="confirm-cancel"]').click();
+  });
+
+  it('exception flow - empty state', () => {
+    cy.intercept('GET', '/appointments', { appointments: [] }).as('noAppt');
+    cy.setCookie('token', 'patient');
+    cy.visit('/appointments');
+    cy.wait('@noAppt');
+    cy.get('[data-testid="no-appointments"]').should('exist');
+  });
+});

--- a/frontend/cypress/e2e/app/doctors.cy.js
+++ b/frontend/cypress/e2e/app/doctors.cy.js
@@ -1,0 +1,31 @@
+/// <reference types="cypress" />
+
+describe('Doctors use case', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '/users/doctors', {
+      doctors: [
+        { id: '1', name: 'Ana', email: 'ana@example.com', specialty: 'Cardio' },
+        { id: '2', name: 'Bruno', email: 'bruno@example.com', specialty: 'Orto' },
+      ],
+      count: 2,
+    });
+    cy.visit('/doctors');
+  });
+
+  it('principal flow - list doctors', () => {
+    cy.get('[data-testid="doctor-card"]').should('have.length', 2);
+  });
+
+  it('alternative flow - filter by specialty', () => {
+    cy.get('[data-testid="specialty-filter"]').select('Cardio');
+    cy.get('[data-testid="apply-filter"]').click();
+    cy.get('[data-testid="doctor-card"]').should('have.length', 1);
+  });
+
+  it('exception flow - handle api error', () => {
+    cy.intercept('GET', '/users/doctors', { statusCode: 500 }).as('getErr');
+    cy.reload();
+    cy.wait('@getErr');
+    cy.contains('Nenhum médico encontrado');
+  });
+});

--- a/frontend/cypress/e2e/app/patients.cy.js
+++ b/frontend/cypress/e2e/app/patients.cy.js
@@ -1,0 +1,29 @@
+/// <reference types="cypress" />
+
+describe('Patients use case', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '/users/patients', [
+      { id: '1', name: 'Carlos', email: 'c@example.com' }
+    ]);
+    cy.intercept('GET', '/appointments', []);
+  });
+
+  it('principal flow - list patients for doctor', () => {
+    cy.setCookie('token', 'doctor');
+    cy.visit('/patients');
+    cy.contains('Carlos');
+  });
+
+  it('alternative flow - search by name', () => {
+    cy.setCookie('token', 'doctor');
+    cy.visit('/patients');
+    cy.get('input[placeholder="Buscar paciente por nome ou email..."]').type('Carlos');
+    cy.contains('Carlos');
+  });
+
+  it('exception flow - redirect patient user', () => {
+    cy.setCookie('token', 'patient');
+    cy.visit('/patients');
+    cy.url().should('include', '/dashboard');
+  });
+});

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1'
+  },
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts']
+};

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/frontend/src/services/__tests__/appointments.service.test.ts
+++ b/frontend/src/services/__tests__/appointments.service.test.ts
@@ -1,0 +1,18 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { appointmentsService } from '../appointments.service';
+
+const mock = new MockAdapter(axios);
+
+afterEach(() => {
+  mock.reset();
+});
+
+describe('appointmentsService', () => {
+  test('createAppointment posts data', async () => {
+    const appointment = { id: '1', doctorId: 'd1', patientId: 'p1', date: '2024-01-01', status: 'SCHEDULED' };
+    mock.onPost('/appointments').reply(200, appointment);
+    const result = await appointmentsService.createAppointment({ doctorId: 'd1', date: '2024-01-01', time: '10:00' });
+    expect(result.id).toBe('1');
+  });
+});

--- a/frontend/src/services/__tests__/users.service.test.ts
+++ b/frontend/src/services/__tests__/users.service.test.ts
@@ -1,0 +1,24 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { usersService } from '../users.service';
+
+const mock = new MockAdapter(axios);
+
+afterEach(() => {
+  mock.reset();
+});
+
+describe('usersService', () => {
+  test('getDoctors returns doctors list', async () => {
+    mock.onGet('/users/doctors').reply(200, { doctors: [{ id: '1', name: 'John', email: 'j@e.com', specialty: 'Cardio' }], count: 1 });
+    const result = await usersService.getDoctors();
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('John');
+  });
+
+  test('getDoctor returns doctor details', async () => {
+    mock.onGet('/users/doctors/1').reply(200, { id: '1', name: 'John', email: 'j@e.com', specialty: 'Cardio' });
+    const doctor = await usersService.getDoctor('1');
+    expect(doctor.id).toBe('1');
+  });
+});

--- a/frontend/src/utils/__tests__/format.test.ts
+++ b/frontend/src/utils/__tests__/format.test.ts
@@ -1,0 +1,15 @@
+import { formatAppointmentStatus, formatUserRole, getStatusColor } from '../format';
+
+describe('format utilities', () => {
+  test('formatAppointmentStatus returns label', () => {
+    expect(formatAppointmentStatus('SCHEDULED')).toBe('Agendada');
+  });
+
+  test('formatUserRole returns label', () => {
+    expect(formatUserRole('DOCTOR')).toBe('Médico');
+  });
+
+  test('getStatusColor returns default for unknown status', () => {
+    expect(getStatusColor('UNKNOWN' as any)).toBe('bg-gray-100 text-gray-800');
+  });
+});


### PR DESCRIPTION
## Summary
- add initial Jest setup with example unit tests
- create integration tests for API service modules
- add Cypress system tests for doctors, patients and appointments pages
- provide a basic test plan

## Testing
- `pnpm test` *(fails: unable to download pnpm)*
- `pnpm run cypress:headless` *(fails: unable to download pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_686eaecbb620832a874997a944f6a6ba